### PR TITLE
Use offsetof() from <stddef.h> instead of our own macro

### DIFF
--- a/cleaved/cleaved.c
+++ b/cleaved/cleaved.c
@@ -33,6 +33,7 @@
  */
 #define _GNU_SOURCE
 #include <getopt.h>
+#include <stddef.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -147,8 +148,6 @@ reopen_logfile(char const *name)
 }
 
 /********************* List handling *******************/
-
-#define offsetof(_type, _member) ((size_t) &((_type *)0)->_member)
 
 #define list_entry(_ptr, _type, _member)			\
 	((_type *)((char *)(_ptr) - offsetof(_type, _member)))


### PR DESCRIPTION
Building with clang 3.4 fails because it complains that we redefine
the offsetof() macro, because <stddef.h> is included through some
implicit path.  Since offsetof() is a standard part of <stddef.h> at
least since C99, let's switch to including <stddef.h> explicitly and
delete of our local version of offsetof().

Signed-off-by: Roland Dreier roland@purestorage.com
